### PR TITLE
docs: annotate the Notification struct

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,6 +2,8 @@ name: Release-Tag
 on:
   push:
     branches: [ master ] 
+    paths-ignore:
+      - '**.md'
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/notificationserver/datastructures.go
+++ b/notificationserver/datastructures.go
@@ -1,8 +1,22 @@
 package notificationserver
 
-// Notification passed between servers
+// Notification is a notification passed between the Gateway servers
 type Notification struct {
-	Target            map[string]string `json:"target"`
-	SendSynchronicity bool              `json:"sendSynchronicity"`
-	Notification      interface{}       `json:"notification"`
+	// Target for the notification
+	//
+	// Describes attributes of the target that should receive the notification
+	//
+	// Required: true
+	// Example: { "cluster": "minikube", "customerGUID": "b5b28ef9-d297-4a93-aec4-22de5b21e802", "component": "websocket" }
+	Target map[string]string `json:"target"`
+	// Whether to send the message synchronously
+	//
+	// If `true`, waits for the message to be sent, else the message is sent asynchronously.
+	// Example: true
+	// Default: false
+	SendSynchronicity bool `json:"sendSynchronicity"`
+	// Body of the notification
+	//
+	// Example: { "commands": [ { "CommandName": "kubescapeScan", "args": { "scanV1": { "submit": true, "excludeNamespaces": ["kube-system"] } } } ] }
+	Notification interface{} `json:"notification"`
 }


### PR DESCRIPTION
# What this PR changes

This PR adds comments to the `Notification` struct. The provided comments can then be used to generate an OpenAPI schema from the source code using `go-swagger`.

It also adds a change that will skip running the CI pipeline if a commit changes only Markdown files.